### PR TITLE
Add solution file and update README build instructions

### DIFF
--- a/ASL.CodeEngineering.sln
+++ b/ASL.CodeEngineering.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ASL.CodeEngineering.AI", "src/ASL.CodeEngineering.AI/ASL.CodeEngineering.AI.csproj", "{d6614205-68e2-4a5c-a107-9ca3bd9a3d1a}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ASL.CodeEngineering.App", "src/ASL.CodeEngineering.App/ASL.CodeEngineering.App.csproj", "{6be541d5-19ec-4c77-bbf5-d936dbe9e7dd}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {d6614205-68e2-4a5c-a107-9ca3bd9a3d1a}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {d6614205-68e2-4a5c-a107-9ca3bd9a3d1a}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {d6614205-68e2-4a5c-a107-9ca3bd9a3d1a}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {d6614205-68e2-4a5c-a107-9ca3bd9a3d1a}.Release|Any CPU.Build.0 = Release|Any CPU
+        {6be541d5-19ec-4c77-bbf5-d936dbe9e7dd}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {6be541d5-19ec-4c77-bbf5-d936dbe9e7dd}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {6be541d5-19ec-4c77-bbf5-d936dbe9e7dd}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {6be541d5-19ec-4c77-bbf5-d936dbe9e7dd}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ autonomous code engineering tool. Currently the project includes:
 - `ASL.CodeEngineering.AI` – library defining the `IAIProvider` interface and a
   sample `EchoAIProvider`.
 
-Run `dotnet build` on each project to compile (requires the .NET SDK).
+Run `dotnet build ASL.CodeEngineering.sln` to build all projects (requires the .NET SDK).
+
+To launch the WPF application, run `dotnet run --project src/ASL.CodeEngineering.App`.
 
 Initial structure for the autonomous polyglot code engineering system.
 


### PR DESCRIPTION
## Summary
- add ASL.CodeEngineering.sln referencing AI and App projects
- document how to build the solution and run the WPF app

## Testing
- `dotnet build ASL.CodeEngineering.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6c532520833292655ad21c0ae3e8