### PR TITLE
Handle chat send button state

### DIFF
--- a/src/ASL.CodeEngineering.App/MainWindow.xaml
+++ b/src/ASL.CodeEngineering.App/MainWindow.xaml
@@ -4,12 +4,15 @@
         Title="ASL.CodeEngineering" Height="350" Width="525">
     <Grid Margin="10">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <TextBox x:Name="PromptTextBox" Grid.Row="0" Margin="0 0 0 5" />
-        <Button x:Name="SendButton" Grid.Row="1" Content="Send" Width="75" Click="SendButton_Click" />
+        <StackPanel Grid.Row="1" Orientation="Horizontal">
+            <Button x:Name="SendButton" Content="Send" Width="75" Click="SendButton_Click" />
+            <TextBlock x:Name="StatusTextBlock" Margin="10 0" VerticalAlignment="Center" />
+        </StackPanel>
         <TextBox x:Name="ResponseTextBox" Grid.Row="2" Margin="0 5 0 0" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True" />
 
     </Grid>

--- a/src/ASL.CodeEngineering.App/MainWindow.xaml.cs
+++ b/src/ASL.CodeEngineering.App/MainWindow.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Windows;
 using ASL.CodeEngineering.AI;
@@ -22,9 +23,24 @@ namespace ASL.CodeEngineering
             if (string.IsNullOrWhiteSpace(prompt))
                 return;
 
-            ResponseTextBox.Text = "Sending...";
-            string response = await _aiProvider.SendChatAsync(prompt, CancellationToken.None);
-            ResponseTextBox.Text = response;
+            SendButton.IsEnabled = false;
+            StatusTextBlock.Text = "Sending...";
+
+            try
+            {
+                string response = await _aiProvider.SendChatAsync(prompt, CancellationToken.None);
+                ResponseTextBox.Text = response;
+                StatusTextBlock.Text = "Done";
+            }
+            catch (Exception ex)
+            {
+                ResponseTextBox.Text = ex.Message;
+                StatusTextBlock.Text = "Error";
+            }
+            finally
+            {
+                SendButton.IsEnabled = true;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- update layout to include a status indicator
- disable Send button while waiting for the response
- show status text and display errors in the response box

## Testing
- `dotnet build ASL.CodeEngineering.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c7626fc1883329284970fd47ea026