### PR TITLE
Add AI provider selection UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Providers must implement the `IAIProvider` interface defined in
 `OpenAIProvider` reads its API key from the `OPENAI_API_KEY` environment
 variable or a local `openai_api_key.txt` file.
 
+## Choosing an AI provider
+
+When the application starts, a dropdown appears at the top of the main window
+listing all available providers. Select a provider (e.g., **Echo** or
+**OpenAI**) before sending a prompt. The selection determines which
+`IAIProvider` implementation handles your chat messages.
+
 ### Security and privacy
 
 Providers such as `OpenAIProvider` communicate with external services over the

--- a/src/ASL.CodeEngineering.App/MainWindow.xaml
+++ b/src/ASL.CodeEngineering.App/MainWindow.xaml
@@ -6,14 +6,16 @@
         <Grid.RowDefinitions>
         <RowDefinition Height="Auto" />
         <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
         <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TextBox x:Name="PromptTextBox" Grid.Row="0" Margin="0 0 0 5" />
-        <StackPanel Grid.Row="1" Orientation="Horizontal">
+        <ComboBox x:Name="ProviderComboBox" Grid.Row="0" Margin="0 0 0 5" SelectionChanged="ProviderComboBox_SelectionChanged" />
+        <TextBox x:Name="PromptTextBox" Grid.Row="1" Margin="0 0 0 5" />
+        <StackPanel Grid.Row="2" Orientation="Horizontal">
             <Button x:Name="SendButton" Content="Send" Width="75" Click="SendButton_Click" />
             <TextBlock x:Name="StatusTextBlock" Margin="10 0" VerticalAlignment="Center" />
         </StackPanel>
-        <TextBox x:Name="ResponseTextBox" Grid.Row="2" Margin="0 5 0 0" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True" />
+        <TextBox x:Name="ResponseTextBox" Grid.Row="3" Margin="0 5 0 0" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True" />
 
     </Grid>
 </Window>

--- a/src/ASL.CodeEngineering.App/MainWindow.xaml.cs
+++ b/src/ASL.CodeEngineering.App/MainWindow.xaml.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Windows;
+using System.Windows.Controls;
 using ASL.CodeEngineering.AI;
 
 namespace ASL.CodeEngineering
@@ -8,12 +10,27 @@ namespace ASL.CodeEngineering
     public partial class MainWindow : Window
     {
 
-        private readonly IAIProvider _aiProvider = new EchoAIProvider();
+        private readonly Dictionary<string, Func<IAIProvider>> _providerFactories = new();
+        private IAIProvider _aiProvider = new EchoAIProvider();
 
 
         public MainWindow()
         {
             InitializeComponent();
+
+            _providerFactories["Echo"] = () => new EchoAIProvider();
+            _providerFactories["OpenAI"] = () => new OpenAIProvider();
+            ProviderComboBox.ItemsSource = _providerFactories.Keys;
+            ProviderComboBox.SelectedIndex = 0;
+        }
+
+        private void ProviderComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (ProviderComboBox.SelectedItem is string key &&
+                _providerFactories.TryGetValue(key, out var factory))
+            {
+                _aiProvider = factory();
+            }
         }
 
 


### PR DESCRIPTION
## Summary
- add combo box to choose AI provider at runtime
- load provider based on selection
- document how to switch providers

## Testing
- `dotnet test -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8bfe24cc83329530129ec2fcdca2