### PR TITLE
Ignore OpenAI API key file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -404,3 +404,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# OpenAI API key
+openai_api_key.txt


### PR DESCRIPTION
## Summary
- update `.gitignore` to exclude `openai_api_key.txt`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8de9f1408332afe4718c562041af