### PR TITLE
Add new unit tests for provider behavior

### DIFF
--- a/tests/ASL.CodeEngineering.Tests/ASL.CodeEngineering.Tests.csproj
+++ b/tests/ASL.CodeEngineering.Tests/ASL.CodeEngineering.Tests.csproj
@@ -1,6 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -9,8 +10,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Xunit.StaFact" Version="1.0.55" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\ASL.CodeEngineering.AI\ASL.CodeEngineering.AI.csproj" />
+    <ProjectReference Include="..\src\ASL.CodeEngineering.App\ASL.CodeEngineering.App.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/ASL.CodeEngineering.Tests/MainWindowTests.cs
+++ b/tests/ASL.CodeEngineering.Tests/MainWindowTests.cs
@@ -1,0 +1,25 @@
+using System.Reflection;
+using ASL.CodeEngineering;
+using ASL.CodeEngineering.AI;
+using Xunit;
+
+namespace ASL.CodeEngineering.Tests;
+
+public class MainWindowTests
+{
+    [StaFact]
+    public void ProviderSelection_UpdatesActiveProvider()
+    {
+        var window = new MainWindow();
+
+        var field = typeof(MainWindow).GetField("_aiProvider", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        Assert.IsType<EchoAIProvider>(field.GetValue(window));
+
+        window.ProviderComboBox.SelectedItem = "OpenAI";
+        Assert.IsType<OpenAIProvider>(field.GetValue(window));
+
+        window.ProviderComboBox.SelectedItem = "Echo";
+        Assert.IsType<EchoAIProvider>(field.GetValue(window));
+        window.Close();
+    }
+}

--- a/tests/ASL.CodeEngineering.Tests/OpenAIProviderTests.cs
+++ b/tests/ASL.CodeEngineering.Tests/OpenAIProviderTests.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ASL.CodeEngineering.AI;
+using Xunit;
+
+namespace ASL.CodeEngineering.Tests;
+
+public class OpenAIProviderTests
+{
+    [Fact]
+    public async Task SendChatAsync_NoApiKey_ThrowsInvalidOperationException()
+    {
+        var originalKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+        Environment.SetEnvironmentVariable("OPENAI_API_KEY", null);
+
+        var keyFile = Path.Combine(AppContext.BaseDirectory, "openai_api_key.txt");
+        if (File.Exists(keyFile))
+            File.Delete(keyFile);
+
+        try
+        {
+            var provider = new OpenAIProvider();
+            await Assert.ThrowsAsync<InvalidOperationException>(() => provider.SendChatAsync("hi", CancellationToken.None));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("OPENAI_API_KEY", originalKey);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add failing key test for `OpenAIProvider`
- verify `MainWindow` uses selected AI provider
- enable WPF support and STA tests in the test project

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d91445c9c83328a47bc2cafa1af0f