### PR TITLE
Clarify OpenAI key placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ Providers must implement the `IAIProvider` interface defined in
 `src/ASL.CodeEngineering.AI/IAIProvider.cs`. New providers can be placed under
 `ai_providers/` and referenced from the application. The example
 `OpenAIProvider` reads its API key from the `OPENAI_API_KEY` environment
-variable or a local `openai_api_key.txt` file.
+variable or a local `openai_api_key.txt` file. When using the file approach,
+place `openai_api_key.txt` in the same directory as the built application
+(for example `src/ASL.CodeEngineering.App/bin/Debug/net7.0-windows/`). The
+repository `.gitignore` already excludes this file so you do not accidentally
+commit your secret key.
 
 ## Choosing an AI provider
 


### PR DESCRIPTION
## Summary
- document how to provide `openai_api_key.txt` next to the built application
- mention that `.gitignore` already excludes the key file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d9b6371248332ab2e9c1093f1eded