### PR TITLE
Add dynamic AI provider loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Initial structure for the autonomous polyglot code engineering system.
 
 Providers must implement the `IAIProvider` interface defined in
 `src/ASL.CodeEngineering.AI/IAIProvider.cs`. New providers can be placed under
-`ai_providers/` and referenced from the application. The example
+`ai_providers/` and the application will automatically scan this folder for
+provider assemblies at startup. Dropping a compiled DLL into the directory makes
+it appear in the provider list. The example
 `OpenAIProvider` reads its API key from the `OPENAI_API_KEY` environment
 variable or a local `openai_api_key.txt` file. When using the file approach,
 place `openai_api_key.txt` in the same directory as the built application

--- a/src/ASL.CodeEngineering.AI/AIProviderLoader.cs
+++ b/src/ASL.CodeEngineering.AI/AIProviderLoader.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace ASL.CodeEngineering.AI;
+
+public static class AIProviderLoader
+{
+    /// <summary>
+    /// Scans the application's <c>ai_providers</c> directory for assemblies and
+    /// returns factories for all discovered <see cref="IAIProvider"/> types.
+    /// </summary>
+    /// <param name="baseDirectory">Directory to search from, typically <see cref="AppContext.BaseDirectory"/>.</param>
+    public static IDictionary<string, Func<IAIProvider>> LoadProviders(string? baseDirectory = null)
+    {
+        baseDirectory ??= AppContext.BaseDirectory;
+        var providers = new Dictionary<string, Func<IAIProvider>>();
+        var path = Path.Combine(baseDirectory, "ai_providers");
+        if (!Directory.Exists(path))
+            return providers;
+
+        foreach (var file in Directory.GetFiles(path, "*.dll"))
+        {
+            Assembly assembly;
+            try
+            {
+                assembly = Assembly.LoadFrom(file);
+            }
+            catch
+            {
+                continue; // Skip invalid assemblies
+            }
+
+            Type[] types;
+            try
+            {
+                types = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                types = ex.Types.Where(t => t != null).ToArray()!;
+            }
+
+            foreach (var type in types)
+            {
+                if (type is null)
+                    continue;
+                if (!typeof(IAIProvider).IsAssignableFrom(type) || type.IsAbstract || type.IsInterface)
+                    continue;
+                if (type.GetConstructor(Type.EmptyTypes) == null)
+                    continue;
+
+                try
+                {
+                    var instance = (IAIProvider)Activator.CreateInstance(type)!;
+                    var name = instance.Name;
+                    if (!string.IsNullOrWhiteSpace(name) && !providers.ContainsKey(name))
+                        providers[name] = () => (IAIProvider)Activator.CreateInstance(type)!;
+                }
+                catch
+                {
+                    // Ignore types that fail to instantiate
+                }
+            }
+        }
+
+        return providers;
+    }
+}

--- a/src/ASL.CodeEngineering.App/MainWindow.xaml.cs
+++ b/src/ASL.CodeEngineering.App/MainWindow.xaml.cs
@@ -20,6 +20,13 @@ namespace ASL.CodeEngineering
 
             _providerFactories["Echo"] = () => new EchoAIProvider();
             _providerFactories["OpenAI"] = () => new OpenAIProvider();
+
+            foreach (var pair in AIProviderLoader.LoadProviders(AppContext.BaseDirectory))
+            {
+                if (!_providerFactories.ContainsKey(pair.Key))
+                    _providerFactories[pair.Key] = pair.Value;
+            }
+
             ProviderComboBox.ItemsSource = _providerFactories.Keys;
             ProviderComboBox.SelectedIndex = 0;
         }


### PR DESCRIPTION
## Summary
- add `AIProviderLoader` to load provider assemblies from **ai_providers/**
- load discovered providers in `MainWindow`
- document automatic provider scanning in README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d9e0dfdac833299bf1d2fc92836c1