### PR TITLE
Add dynamic provider fixture

### DIFF
--- a/tests/ASL.CodeEngineering.Tests/AIProviderLoaderTests.cs
+++ b/tests/ASL.CodeEngineering.Tests/AIProviderLoaderTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+using ASL.CodeEngineering;
+using ASL.CodeEngineering.AI;
+using Xunit;
+
+namespace ASL.CodeEngineering.Tests;
+
+[CollectionDefinition("ProviderFixture")] 
+public class ProviderFixtureCollection : ICollectionFixture<CompileProviderFixture> { }
+
+[Collection("ProviderFixture")]
+public class AIProviderLoaderTests
+{
+    private readonly CompileProviderFixture _fixture;
+
+    public AIProviderLoaderTests(CompileProviderFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void Loader_DetectsRuntimeCompiledProvider()
+    {
+        var providers = AIProviderLoader.LoadProviders(AppContext.BaseDirectory);
+        Assert.Contains("Dummy", providers.Keys);
+    }
+
+    [StaFact]
+    public void MainWindow_ListsRuntimeCompiledProvider()
+    {
+        var window = new MainWindow();
+        var items = window.ProviderComboBox.Items.OfType<string>().ToArray();
+        Assert.Contains("Dummy", items);
+        window.Close();
+    }
+}

--- a/tests/ASL.CodeEngineering.Tests/ASL.CodeEngineering.Tests.csproj
+++ b/tests/ASL.CodeEngineering.Tests/ASL.CodeEngineering.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="Xunit.StaFact" Version="1.0.55" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\ASL.CodeEngineering.AI\ASL.CodeEngineering.AI.csproj" />

--- a/tests/ASL.CodeEngineering.Tests/CompileProviderFixture.cs
+++ b/tests/ASL.CodeEngineering.Tests/CompileProviderFixture.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using ASL.CodeEngineering.AI;
+
+namespace ASL.CodeEngineering.Tests;
+
+public class CompileProviderFixture : IDisposable
+{
+    public string ProvidersDirectory { get; };
+
+    public CompileProviderFixture()
+    {
+        ProvidersDirectory = Path.Combine(AppContext.BaseDirectory, "ai_providers");
+        Directory.CreateDirectory(ProvidersDirectory);
+        CompileDummyProvider();
+    }
+
+    private void CompileDummyProvider()
+    {
+        const string code = """
+using System.Threading;
+using System.Threading.Tasks;
+using ASL.CodeEngineering.AI;
+
+public class DummyProvider : IAIProvider
+{
+    public string Name => "Dummy";
+    public Task<string> SendChatAsync(string prompt, CancellationToken cancellationToken = default)
+        => Task.FromResult("dummy:" + prompt);
+}
+""";
+
+        var syntax = CSharpSyntaxTree.ParseText(code);
+        var references = new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Task).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(IAIProvider).Assembly.Location),
+        };
+
+        var compilation = CSharpCompilation.Create(
+            "DummyProvider",
+            new[] { syntax },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var path = Path.Combine(ProvidersDirectory, "DummyProvider.dll");
+        var result = compilation.Emit(path);
+        if (!result.Success)
+        {
+            throw new InvalidOperationException("Failed to compile dummy provider: " +
+                string.Join(Environment.NewLine, result.Diagnostics));
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(ProvidersDirectory))
+            Directory.Delete(ProvidersDirectory, true);
+    }
+}


### PR DESCRIPTION
## Summary
- add Microsoft.CodeAnalysis.CSharp dependency for runtime compilation
- introduce `CompileProviderFixture` that builds a dummy provider into `ai_providers`
- test that loader and `MainWindow` detect the dynamic provider

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d9f64843c8332b1d6dc6aec1109f8