### PR TITLE
Add plugin architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ place `openai_api_key.txt` in the same directory as the built application
 repository `.gitignore` already excludes this file so you do not accidentally
 commit your secret key.
 
+## Extending plugins
+
+Analyzer and code runner plugins work just like AI providers. Implement
+`IAnalyzerPlugin` or `ICodeRunnerPlugin` in a class library that references
+`ASL.CodeEngineering.AI`, build the assembly and drop the resulting DLL into
+the `plugins/` directory next to the application executable. The application
+automatically loads all plugins found in this folder at startup.
+
 ## Choosing an AI provider
 
 When the application starts, a dropdown appears at the top of the main window

--- a/src/ASL.CodeEngineering.AI/DotnetVersionRunner.cs
+++ b/src/ASL.CodeEngineering.AI/DotnetVersionRunner.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ASL.CodeEngineering.AI;
+
+public class DotnetVersionRunner : ICodeRunnerPlugin
+{
+    public string Name => "DotnetVersion";
+
+    public async Task<string> RunAsync(string workingDirectory, CancellationToken cancellationToken = default)
+    {
+        var psi = new ProcessStartInfo("dotnet", "--version")
+        {
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = workingDirectory
+        };
+        using var process = Process.Start(psi)!;
+        var output = await process.StandardOutput.ReadToEndAsync();
+        await process.WaitForExitAsync(cancellationToken);
+        return output.Trim();
+    }
+}

--- a/src/ASL.CodeEngineering.AI/IAnalyzerPlugin.cs
+++ b/src/ASL.CodeEngineering.AI/IAnalyzerPlugin.cs
@@ -1,0 +1,7 @@
+namespace ASL.CodeEngineering.AI;
+
+public interface IAnalyzerPlugin
+{
+    string Name { get; }
+    Task<string> AnalyzeAsync(string code, CancellationToken cancellationToken = default);
+}

--- a/src/ASL.CodeEngineering.AI/ICodeRunnerPlugin.cs
+++ b/src/ASL.CodeEngineering.AI/ICodeRunnerPlugin.cs
@@ -1,0 +1,7 @@
+namespace ASL.CodeEngineering.AI;
+
+public interface ICodeRunnerPlugin
+{
+    string Name { get; }
+    Task<string> RunAsync(string workingDirectory, CancellationToken cancellationToken = default);
+}

--- a/src/ASL.CodeEngineering.AI/PluginLoader.cs
+++ b/src/ASL.CodeEngineering.AI/PluginLoader.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace ASL.CodeEngineering.AI;
+
+public static class PluginLoader
+{
+    public static IDictionary<string, Func<IAnalyzerPlugin>> LoadAnalyzers(string? baseDirectory = null)
+        => LoadPlugins<IAnalyzerPlugin>(baseDirectory);
+
+    public static IDictionary<string, Func<ICodeRunnerPlugin>> LoadRunners(string? baseDirectory = null)
+        => LoadPlugins<ICodeRunnerPlugin>(baseDirectory);
+
+    private static IDictionary<string, Func<T>> LoadPlugins<T>(string? baseDirectory)
+    {
+        baseDirectory ??= AppContext.BaseDirectory;
+        var plugins = new Dictionary<string, Func<T>>();
+        var sources = new Dictionary<string, string>();
+        var path = Path.Combine(baseDirectory, "plugins");
+        if (!Directory.Exists(path))
+            return plugins;
+
+        foreach (var file in Directory.GetFiles(path, "*.dll"))
+        {
+            Assembly assembly;
+            try
+            {
+                assembly = Assembly.LoadFrom(file);
+            }
+            catch
+            {
+                continue;
+            }
+
+            Type[] types;
+            try
+            {
+                types = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                types = ex.Types.Where(t => t != null).ToArray()!;
+            }
+
+            foreach (var type in types)
+            {
+                if (type is null)
+                    continue;
+                if (!typeof(T).IsAssignableFrom(type) || type.IsAbstract || type.IsInterface)
+                    continue;
+                if (type.GetConstructor(Type.EmptyTypes) == null)
+                    continue;
+
+                try
+                {
+                    var instance = (T)Activator.CreateInstance(type)!;
+                    var nameProp = typeof(T).GetProperty("Name");
+                    var name = (string?)nameProp?.GetValue(instance);
+                    if (string.IsNullOrWhiteSpace(name))
+                        continue;
+                    if (plugins.ContainsKey(name!))
+                    {
+                        var message = $"Duplicate plugin name '{name}' found in '{file}'. Original from '{sources[name!]}'";
+                        Debug.WriteLine(message);
+                        continue;
+                    }
+                    plugins[name!] = () => (T)Activator.CreateInstance(type)!;
+                    sources[name!] = file;
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+        }
+
+        return plugins.OrderBy(p => p.Key).ToDictionary(p => p.Key, p => p.Value);
+    }
+}

--- a/src/ASL.CodeEngineering.AI/TodoAnalyzer.cs
+++ b/src/ASL.CodeEngineering.AI/TodoAnalyzer.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ASL.CodeEngineering.AI;
+
+public class TodoAnalyzer : IAnalyzerPlugin
+{
+    public string Name => "Todo";
+
+    public Task<string> AnalyzeAsync(string code, CancellationToken cancellationToken = default)
+    {
+        var result = code.Contains("TODO", StringComparison.OrdinalIgnoreCase)
+            ? "TODO found"
+            : "No TODO";
+        return Task.FromResult(result);
+    }
+}

--- a/src/ASL.CodeEngineering.App/MainWindow.xaml
+++ b/src/ASL.CodeEngineering.App/MainWindow.xaml
@@ -4,18 +4,28 @@
         Title="ASL.CodeEngineering" Height="350" Width="525">
     <Grid Margin="10">
         <Grid.RowDefinitions>
-        <RowDefinition Height="Auto" />
-        <RowDefinition Height="Auto" />
-        <RowDefinition Height="Auto" />
-        <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <ComboBox x:Name="ProviderComboBox" Grid.Row="0" Margin="0 0 0 5" SelectionChanged="ProviderComboBox_SelectionChanged" />
-        <TextBox x:Name="PromptTextBox" Grid.Row="1" Margin="0 0 0 5" />
+        <StackPanel Grid.Row="1" Orientation="Horizontal">
+            <ComboBox x:Name="AnalyzerComboBox" Width="150" SelectionChanged="AnalyzerComboBox_SelectionChanged" />
+            <Button x:Name="AnalyzeButton" Content="Analyze" Width="75" Margin="5 0 0 0" Click="AnalyzeButton_Click" />
+        </StackPanel>
         <StackPanel Grid.Row="2" Orientation="Horizontal">
+            <ComboBox x:Name="RunnerComboBox" Width="150" SelectionChanged="RunnerComboBox_SelectionChanged" />
+            <Button x:Name="RunButton" Content="Run" Width="75" Margin="5 0 0 0" Click="RunButton_Click" />
+        </StackPanel>
+        <TextBox x:Name="PromptTextBox" Grid.Row="3" Margin="0 0 0 5" />
+        <StackPanel Grid.Row="4" Orientation="Horizontal">
             <Button x:Name="SendButton" Content="Send" Width="75" Click="SendButton_Click" />
             <TextBlock x:Name="StatusTextBlock" Margin="10 0" VerticalAlignment="Center" />
         </StackPanel>
-        <TextBox x:Name="ResponseTextBox" Grid.Row="3" Margin="0 5 0 0" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True" />
+        <TextBox x:Name="ResponseTextBox" Grid.Row="5" Margin="0 5 0 0" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True" />
 
     </Grid>
 </Window>

--- a/src/ASL.CodeEngineering.App/MainWindow.xaml.cs
+++ b/src/ASL.CodeEngineering.App/MainWindow.xaml.cs
@@ -13,7 +13,11 @@ namespace ASL.CodeEngineering
     {
 
         private readonly Dictionary<string, Func<IAIProvider>> _providerFactories = new();
+        private readonly Dictionary<string, Func<IAnalyzerPlugin>> _analyzerFactories = new();
+        private readonly Dictionary<string, Func<ICodeRunnerPlugin>> _runnerFactories = new();
         private IAIProvider _aiProvider = new EchoAIProvider();
+        private IAnalyzerPlugin? _analyzer;
+        private ICodeRunnerPlugin? _runner;
 
 
         public MainWindow()
@@ -23,14 +27,33 @@ namespace ASL.CodeEngineering
             _providerFactories["Echo"] = () => new EchoAIProvider();
             _providerFactories["OpenAI"] = () => new OpenAIProvider();
 
+            _analyzerFactories["Todo"] = () => new TodoAnalyzer();
+            _runnerFactories["DotnetVersion"] = () => new DotnetVersionRunner();
+
             foreach (var pair in AIProviderLoader.LoadProviders(AppContext.BaseDirectory))
             {
                 if (!_providerFactories.ContainsKey(pair.Key))
                     _providerFactories[pair.Key] = pair.Value;
             }
 
+            foreach (var pair in PluginLoader.LoadAnalyzers(AppContext.BaseDirectory))
+            {
+                if (!_analyzerFactories.ContainsKey(pair.Key))
+                    _analyzerFactories[pair.Key] = pair.Value;
+            }
+
+            foreach (var pair in PluginLoader.LoadRunners(AppContext.BaseDirectory))
+            {
+                if (!_runnerFactories.ContainsKey(pair.Key))
+                    _runnerFactories[pair.Key] = pair.Value;
+            }
+
             ProviderComboBox.ItemsSource = _providerFactories.Keys;
             ProviderComboBox.SelectedIndex = 0;
+            AnalyzerComboBox.ItemsSource = _analyzerFactories.Keys;
+            AnalyzerComboBox.SelectedIndex = _analyzerFactories.Count > 0 ? 0 : -1;
+            RunnerComboBox.ItemsSource = _runnerFactories.Keys;
+            RunnerComboBox.SelectedIndex = _runnerFactories.Count > 0 ? 0 : -1;
         }
 
         private void ProviderComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -39,6 +62,24 @@ namespace ASL.CodeEngineering
                 _providerFactories.TryGetValue(key, out var factory))
             {
                 _aiProvider = factory();
+            }
+        }
+
+        private void AnalyzerComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (AnalyzerComboBox.SelectedItem is string key &&
+                _analyzerFactories.TryGetValue(key, out var factory))
+            {
+                _analyzer = factory();
+            }
+        }
+
+        private void RunnerComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (RunnerComboBox.SelectedItem is string key &&
+                _runnerFactories.TryGetValue(key, out var factory))
+            {
+                _runner = factory();
             }
         }
 
@@ -76,6 +117,57 @@ namespace ASL.CodeEngineering
                 var entry = new { timestamp = DateTime.UtcNow, prompt, response };
                 string line = JsonSerializer.Serialize(entry);
                 File.AppendAllText(path, line + Environment.NewLine);
+            }
+        }
+
+        private async void AnalyzeButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (_analyzer is null)
+                return;
+            string code = PromptTextBox.Text;
+            if (string.IsNullOrWhiteSpace(code))
+                return;
+
+            AnalyzeButton.IsEnabled = false;
+            StatusTextBlock.Text = "Analyzing...";
+            try
+            {
+                var result = await _analyzer.AnalyzeAsync(code, CancellationToken.None);
+                ResponseTextBox.Text = result;
+                StatusTextBlock.Text = "Done";
+            }
+            catch (Exception ex)
+            {
+                ResponseTextBox.Text = ex.Message;
+                StatusTextBlock.Text = "Error";
+            }
+            finally
+            {
+                AnalyzeButton.IsEnabled = true;
+            }
+        }
+
+        private async void RunButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (_runner is null)
+                return;
+
+            RunButton.IsEnabled = false;
+            StatusTextBlock.Text = "Running...";
+            try
+            {
+                var result = await _runner.RunAsync(AppContext.BaseDirectory, CancellationToken.None);
+                ResponseTextBox.Text = result;
+                StatusTextBlock.Text = "Done";
+            }
+            catch (Exception ex)
+            {
+                ResponseTextBox.Text = ex.Message;
+                StatusTextBlock.Text = "Error";
+            }
+            finally
+            {
+                RunButton.IsEnabled = true;
             }
         }
     }

--- a/tests/ASL.CodeEngineering.Tests/CompilePluginFixture.cs
+++ b/tests/ASL.CodeEngineering.Tests/CompilePluginFixture.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using ASL.CodeEngineering.AI;
+
+namespace ASL.CodeEngineering.Tests;
+
+public class CompilePluginFixture : IDisposable
+{
+    public string BaseDirectory { get; }
+
+    public CompilePluginFixture()
+    {
+        BaseDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(Path.Combine(BaseDirectory, "plugins"));
+        CompileAnalyzer();
+        CompileRunner();
+    }
+
+    private void CompileAnalyzer()
+    {
+        const string code = """
+using System.Threading;
+using System.Threading.Tasks;
+using ASL.CodeEngineering.AI;
+
+public class DummyAnalyzer : IAnalyzerPlugin
+{
+    public string Name => \"DummyAnalyzer\";
+    public Task<string> AnalyzeAsync(string code, CancellationToken cancellationToken = default)
+        => Task.FromResult(\"analyzed:\" + code);
+}
+""";
+        Compile(code, "DummyAnalyzer.dll");
+    }
+
+    private void CompileRunner()
+    {
+        const string code = """
+using System.Threading;
+using System.Threading.Tasks;
+using ASL.CodeEngineering.AI;
+
+public class DummyRunner : ICodeRunnerPlugin
+{
+    public string Name => \"DummyRunner\";
+    public Task<string> RunAsync(string dir, CancellationToken cancellationToken = default)
+        => Task.FromResult(\"ran:\" + dir);
+}
+""";
+        Compile(code, "DummyRunner.dll");
+    }
+
+    private void Compile(string source, string fileName)
+    {
+        var syntax = CSharpSyntaxTree.ParseText(source);
+        var references = new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Task).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(IAnalyzerPlugin).Assembly.Location)
+        };
+
+        var compilation = CSharpCompilation.Create(
+            Path.GetFileNameWithoutExtension(fileName),
+            new[] { syntax },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var path = Path.Combine(BaseDirectory, "plugins", fileName);
+        var result = compilation.Emit(path);
+        if (!result.Success)
+        {
+            throw new InvalidOperationException("Failed to compile plugin: " +
+                string.Join(Environment.NewLine, result.Diagnostics));
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(BaseDirectory))
+            Directory.Delete(BaseDirectory, true);
+    }
+}

--- a/tests/ASL.CodeEngineering.Tests/PluginLoaderTests.cs
+++ b/tests/ASL.CodeEngineering.Tests/PluginLoaderTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using ASL.CodeEngineering;
+using ASL.CodeEngineering.AI;
+using Xunit;
+
+namespace ASL.CodeEngineering.Tests;
+
+[CollectionDefinition("PluginFixture")]
+public class PluginFixtureCollection : ICollectionFixture<CompilePluginFixture> { }
+
+[Collection("PluginFixture")]
+public class PluginLoaderTests
+{
+    private readonly CompilePluginFixture _fixture;
+
+    public PluginLoaderTests(CompilePluginFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void Loader_DetectsRuntimeCompiledPlugins()
+    {
+        var analyzers = PluginLoader.LoadAnalyzers(_fixture.BaseDirectory);
+        var runners = PluginLoader.LoadRunners(_fixture.BaseDirectory);
+        Assert.Contains("DummyAnalyzer", analyzers.Keys);
+        Assert.Contains("DummyRunner", runners.Keys);
+    }
+
+    [StaFact]
+    public void MainWindow_ListsRuntimeCompiledPlugins()
+    {
+        var window = new MainWindow();
+        var analyzers = PluginLoader.LoadAnalyzers(_fixture.BaseDirectory);
+        var runners = PluginLoader.LoadRunners(_fixture.BaseDirectory);
+
+        var fieldA = typeof(MainWindow).GetField("_analyzerFactories", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var fieldR = typeof(MainWindow).GetField("_runnerFactories", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var analyzerFactories = (Dictionary<string, Func<IAnalyzerPlugin>>)fieldA.GetValue(window)!;
+        var runnerFactories = (Dictionary<string, Func<ICodeRunnerPlugin>>)fieldR.GetValue(window)!;
+        foreach (var pair in analyzers)
+            if (!analyzerFactories.ContainsKey(pair.Key))
+                analyzerFactories[pair.Key] = pair.Value;
+        foreach (var pair in runners)
+            if (!runnerFactories.ContainsKey(pair.Key))
+                runnerFactories[pair.Key] = pair.Value;
+        window.AnalyzerComboBox.ItemsSource = analyzerFactories.Keys;
+        window.RunnerComboBox.ItemsSource = runnerFactories.Keys;
+
+        Assert.Contains("DummyAnalyzer", window.AnalyzerComboBox.Items.OfType<string>());
+        Assert.Contains("DummyRunner", window.RunnerComboBox.Items.OfType<string>());
+        window.Close();
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `IAnalyzerPlugin` and `ICodeRunnerPlugin`
- create `PluginLoader` to scan `plugins/` for analyzers and code runners
- add sample `TodoAnalyzer` and `DotnetVersionRunner`
- extend WPF application UI to list analyzers and runners
- document plugin usage in README
- tests compile dummy plugins and verify loader functionality

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685da6dd051083328437ba4f2fb2c3eb