### PR TITLE
Add AvalonEdit and project explorer

### DIFF
--- a/src/ASL.CodeEngineering.App/ASL.CodeEngineering.App.csproj
+++ b/src/ASL.CodeEngineering.App/ASL.CodeEngineering.App.csproj
@@ -3,11 +3,16 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net7.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ASL.CodeEngineering.AI\ASL.CodeEngineering.AI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AvalonEdit" Version="6.1.0" />
   </ItemGroup>
 </Project>

--- a/src/ASL.CodeEngineering.App/MainWindow.xaml
+++ b/src/ASL.CodeEngineering.App/MainWindow.xaml
@@ -1,31 +1,49 @@
 <Window x:Class="ASL.CodeEngineering.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="ASL.CodeEngineering" Height="350" Width="525">
-    <Grid Margin="10">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-        <ComboBox x:Name="ProviderComboBox" Grid.Row="0" Margin="0 0 0 5" SelectionChanged="ProviderComboBox_SelectionChanged" />
-        <StackPanel Grid.Row="1" Orientation="Horizontal">
-            <ComboBox x:Name="AnalyzerComboBox" Width="150" SelectionChanged="AnalyzerComboBox_SelectionChanged" />
-            <Button x:Name="AnalyzeButton" Content="Analyze" Width="75" Margin="5 0 0 0" Click="AnalyzeButton_Click" />
-        </StackPanel>
-        <StackPanel Grid.Row="2" Orientation="Horizontal">
-            <ComboBox x:Name="RunnerComboBox" Width="150" SelectionChanged="RunnerComboBox_SelectionChanged" />
-            <Button x:Name="RunButton" Content="Run" Width="75" Margin="5 0 0 0" Click="RunButton_Click" />
-        </StackPanel>
-        <TextBox x:Name="PromptTextBox" Grid.Row="3" Margin="0 0 0 5" />
-        <StackPanel Grid.Row="4" Orientation="Horizontal">
-            <Button x:Name="SendButton" Content="Send" Width="75" Click="SendButton_Click" />
-            <TextBlock x:Name="StatusTextBlock" Margin="10 0" VerticalAlignment="Center" />
-        </StackPanel>
-        <TextBox x:Name="ResponseTextBox" Grid.Row="5" Margin="0 5 0 0" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True" />
+        xmlns:avalonedit="http://icsharpcode.net/sharpdevelop/avalonedit"
+        Title="ASL.CodeEngineering" Height="600" Width="800">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="200" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <!-- Project Explorer -->
+        <DockPanel Grid.Column="0" LastChildFill="True">
+            <Button x:Name="OpenProjectButton" Content="Open Project" DockPanel.Dock="Top" Margin="5" Click="OpenProjectButton_Click"/>
+            <TreeView x:Name="ProjectTreeView" SelectedItemChanged="ProjectTreeView_SelectedItemChanged"/>
+        </DockPanel>
+
+        <!-- Main Content -->
+        <Grid Grid.Column="1" Margin="10">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="2*" />
+            </Grid.RowDefinitions>
+
+            <ComboBox x:Name="ProviderComboBox" Grid.Row="0" Margin="0 0 0 5" SelectionChanged="ProviderComboBox_SelectionChanged" />
+            <StackPanel Grid.Row="1" Orientation="Horizontal">
+                <ComboBox x:Name="AnalyzerComboBox" Width="150" SelectionChanged="AnalyzerComboBox_SelectionChanged" />
+                <Button x:Name="AnalyzeButton" Content="Analyze" Width="75" Margin="5 0 0 0" Click="AnalyzeButton_Click" />
+            </StackPanel>
+            <StackPanel Grid.Row="2" Orientation="Horizontal">
+                <ComboBox x:Name="RunnerComboBox" Width="150" SelectionChanged="RunnerComboBox_SelectionChanged" />
+                <Button x:Name="RunButton" Content="Run" Width="75" Margin="5 0 0 0" Click="RunButton_Click" />
+            </StackPanel>
+            <TextBox x:Name="PromptTextBox" Grid.Row="3" Margin="0 0 0 5" />
+            <StackPanel Grid.Row="4" Orientation="Horizontal">
+                <Button x:Name="SendButton" Content="Send" Width="75" Click="SendButton_Click" />
+                <TextBlock x:Name="StatusTextBlock" Margin="10 0" VerticalAlignment="Center" />
+            </StackPanel>
+            <TextBox x:Name="ResponseTextBox" Grid.Row="5" Margin="0 5 0 0" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True" />
+            <avalonedit:TextEditor x:Name="CodeEditor" Grid.Row="6" ShowLineNumbers="True" SyntaxHighlighting="C#"/>
+        </Grid>
 
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- integrate AvalonEdit and enable Windows Forms interop
- redesign main window with a project tree and code editor
- load files into the editor with syntax highlighting

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685da83d882c83328ae4f35585bc33b6