### PR TITLE
Add runner tests

### DIFF
--- a/tests/ASL.CodeEngineering.Tests/DotnetBuildTestRunnerTests.cs
+++ b/tests/ASL.CodeEngineering.Tests/DotnetBuildTestRunnerTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using ASL.CodeEngineering.AI;
+using Xunit;
+using Xunit.Sdk;
+
+namespace ASL.CodeEngineering.Tests;
+
+public class DotnetBuildTestRunnerTests
+{
+    [Fact]
+    public async Task BuildAsync_LogsOutputAndReportsExitCode()
+    {
+        if (!TestHelpers.ToolExists("dotnet"))
+            throw new SkipException("dotnet not installed");
+
+        var runner = new DotnetBuildTestRunner();
+        var temp = Directory.CreateTempSubdirectory();
+        try
+        {
+            var logsDir = Path.Combine(AppContext.BaseDirectory, "logs");
+            Directory.CreateDirectory(logsDir);
+            var before = Directory.GetFiles(logsDir);
+
+            string result = await runner.BuildAsync(temp.FullName);
+            Assert.Contains("Exit code", result);
+
+            var after = Directory.GetFiles(logsDir);
+            var newLog = after.Except(before).FirstOrDefault();
+            Assert.NotNull(newLog);
+            var logContent = File.ReadAllText(newLog!);
+            Assert.Contains(result.Trim(), logContent);
+        }
+        finally
+        {
+            Directory.Delete(temp.FullName, true);
+        }
+    }
+}

--- a/tests/ASL.CodeEngineering.Tests/DotnetVersionRunnerTests.cs
+++ b/tests/ASL.CodeEngineering.Tests/DotnetVersionRunnerTests.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using ASL.CodeEngineering.AI;
+using Xunit;
+using Xunit.Sdk;
+
+namespace ASL.CodeEngineering.Tests;
+
+public class DotnetVersionRunnerTests
+{
+    [Fact]
+    public async Task RunAsync_ReturnsVersion()
+    {
+        if (!TestHelpers.ToolExists("dotnet"))
+            throw new SkipException("dotnet not installed");
+
+        var runner = new DotnetVersionRunner();
+        string result = await runner.RunAsync(AppContext.BaseDirectory);
+        Assert.Matches(@"\d+(\.\d+)+", result);
+    }
+}

--- a/tests/ASL.CodeEngineering.Tests/PythonBuildTestRunnerTests.cs
+++ b/tests/ASL.CodeEngineering.Tests/PythonBuildTestRunnerTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using ASL.CodeEngineering.AI;
+using Xunit;
+using Xunit.Sdk;
+
+namespace ASL.CodeEngineering.Tests;
+
+public class PythonBuildTestRunnerTests
+{
+    [Fact]
+    public async Task BuildAsync_LogsOutputAndReportsExitCode()
+    {
+        if (!TestHelpers.ToolExists("python"))
+            throw new SkipException("python not installed");
+
+        var runner = new PythonBuildTestRunner();
+        var temp = Directory.CreateTempSubdirectory();
+        try
+        {
+            File.WriteAllText(Path.Combine(temp.FullName, "bad.py"), "def f(:\n");
+            var logsDir = Path.Combine(AppContext.BaseDirectory, "logs");
+            Directory.CreateDirectory(logsDir);
+            var before = Directory.GetFiles(logsDir);
+
+            string result = await runner.BuildAsync(temp.FullName);
+            Assert.Contains("Exit code", result);
+
+            var after = Directory.GetFiles(logsDir);
+            var newLog = after.Except(before).FirstOrDefault();
+            Assert.NotNull(newLog);
+            var logContent = File.ReadAllText(newLog!);
+            Assert.Contains(result.Trim(), logContent);
+        }
+        finally
+        {
+            Directory.Delete(temp.FullName, true);
+        }
+    }
+}

--- a/tests/ASL.CodeEngineering.Tests/TestHelpers.cs
+++ b/tests/ASL.CodeEngineering.Tests/TestHelpers.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics;
+
+namespace ASL.CodeEngineering.Tests;
+
+public static class TestHelpers
+{
+    public static bool ToolExists(string name)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo(name, "--version")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            using var process = Process.Start(psi);
+            if (process == null)
+                return false;
+            if (!process.WaitForExit(1000))
+                process.Kill(true);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add helpers to detect if runtime tools exist
- test dotnet version runner output
- check logging and exit codes for Dotnet and Python build/test runners

## Testing
- `dotnet test tests/ASL.CodeEngineering.Tests/ASL.CodeEngineering.Tests.csproj` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685db144c96c8332bed2fae21265adbf