### PR TITLE
Log summary failures to logs

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -18,3 +18,5 @@ This file captures the current and upcoming steps for the project. It acts as th
 - [x] Update loaders to detect duplicate plugins/providers and throw descriptive exceptions
 - [x] Add unit tests verifying duplicate detection
 - [x] Run `dotnet test`
+- [x] Log SendChatAsync exceptions to `logs` directory
+- [x] Notify user when summary generation fails

--- a/src/ASL.CodeEngineering.App/MainWindow.xaml.cs
+++ b/src/ASL.CodeEngineering.App/MainWindow.xaml.cs
@@ -132,6 +132,7 @@ namespace ASL.CodeEngineering
                 response = ex.Message;
                 ResponseTextBox.Text = ex.Message;
                 StatusTextBlock.Text = "Error";
+                LogError("SendChat", ex);
             }
 
             SendButton.IsEnabled = true;
@@ -154,6 +155,8 @@ namespace ASL.CodeEngineering
             catch (Exception ex)
             {
                 summary = $"[error: {ex.Message}]";
+                LogError("SummaryGeneration", ex);
+                StatusTextBlock.Text = "Summary Error";
             }
 
             string knowledgeDir = Path.Combine(AppContext.BaseDirectory, "knowledge_base", providerName);
@@ -306,6 +309,14 @@ namespace ASL.CodeEngineering
             {
                 parentItem.Items.Add(new TreeViewItem { Header = Path.GetFileName(file), Tag = file });
             }
+        }
+
+        private static void LogError(string operation, Exception ex)
+        {
+            var logsDir = Path.Combine(AppContext.BaseDirectory, "logs");
+            Directory.CreateDirectory(logsDir);
+            var file = Path.Combine(logsDir, $"{operation}_{DateTime.UtcNow:yyyyMMdd_HHmmss}.log");
+            File.WriteAllText(file, ex.ToString());
         }
     }
 }


### PR DESCRIPTION
## Summary
- log errors from chat and summary generation to logs directory
- signal summary generation error via status text
- document next steps

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbbfcdb9c8332889d78c5c4373b50