### PR TITLE
Add note about Windows-only tests

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -20,3 +20,4 @@ This file captures the current and upcoming steps for the project. It acts as th
 - [x] Run `dotnet test`
 - [x] Log SendChatAsync exceptions to `logs` directory
 - [x] Notify user when summary generation fails
+- [x] Document test environment requirements in README

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ Run `dotnet build ASL.CodeEngineering.sln` to build all projects (requires the .
 To launch the WPF application, run `dotnet run --project src/ASL.CodeEngineering.App`.
 The UI uses WPF and therefore runs only on Windows systems.
 
-Tests can be run with `dotnet test` from the repository root. The .NET SDK must
-be installed and no additional setup is required. Because the test project
-targets `net7.0-windows` with WPF, `dotnet test` must be run on a Windows
-machine.
+## Testing
+
+Unit tests are run with `dotnet test` from the repository root. You need a working .NET SDK and Python installation. Because the test project targets `net7.0-windows`, tests must run on Windows. Individual tests skip automatically when required tools such as `dotnet` or `python` are missing.
 
 Initial structure for the autonomous polyglot code engineering system.
 


### PR DESCRIPTION
## Summary
- explain that tests require Windows with dotnet and Python
- note that tests skip when tools are missing
- update next steps

## Testing
- `dotnet test` *(fails: command not found)*
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dbcecd7c08332bfd62ece0c2dff46