### PR TITLE
Add env dir variables

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -31,3 +31,7 @@ This file captures the current and upcoming steps for the project. It acts as th
 - [x] Use sanitized names for `data` and `knowledge_base` directories
 - [x] Document name sanitization requirement in `ai_providers/README.md`
 - [x] Add test verifying directories created for sanitized provider names
+- [ ] Introduce DATA_DIR, LOGS_DIR and KB_DIR environment variables
+- [ ] Document variables in README and update REFERENCE_FILES
+- [ ] Add tests for environment variable output directories
+- [ ] Run `dotnet test`

--- a/README.md
+++ b/README.md
@@ -30,7 +30,14 @@ Initial structure for the autonomous polyglot code engineering system.
 
 You can override the default locations of the `ai_providers` and `plugins`
 directories by setting the `AI_PROVIDERS_DIR` or `PLUGINS_DIR` environment
-variables.
+variables. The application also respects the following variables for runtime
+data and logs:
+
+- `DATA_DIR` – base directory for chat logs and provider data (defaults to
+  `data/` beside the executable).
+- `KB_DIR` – directory for generated summaries and other knowledge base
+  files (defaults to `knowledge_base/`).
+- `LOGS_DIR` – directory for diagnostic logs (defaults to `logs/`).
 - `tests/` – unit tests for the provider library.
 
 ## Extending AI providers

--- a/REFERENCE_FILES.md
+++ b/REFERENCE_FILES.md
@@ -10,6 +10,8 @@ This list tracks documents, config files and other resources that may need to be
 | `configs/appsettings.json` | Main app configuration; always keep current |
 | `ai_providers/README.md` | Quick reference for building custom providers |
 | `plugins/README.md` | Quick reference for building plugins |
+| `README.md` | Documented environment variables |
 | `src/ASL.CodeEngineering.AI/PathHelpers.cs` | Helper for sanitizing provider names |
+| `src/ASL.CodeEngineering.App/MainWindow.xaml.cs` | Paths respect DATA_DIR, KB_DIR and LOGS_DIR |
 
 Add new entries in the table above with a short explanation of why the file might be needed again.

--- a/src/ASL.CodeEngineering.AI/AIProviderLoader.cs
+++ b/src/ASL.CodeEngineering.AI/AIProviderLoader.cs
@@ -98,7 +98,8 @@ public static class AIProviderLoader
         Debug.WriteLine($"{context}: {ex}");
         try
         {
-            var logsDir = Path.Combine(AppContext.BaseDirectory, "logs");
+            var logsDir = Environment.GetEnvironmentVariable("LOGS_DIR") ??
+                          Path.Combine(AppContext.BaseDirectory, "logs");
             Directory.CreateDirectory(logsDir);
             var file = Path.Combine(logsDir, $"{context}_{DateTime.UtcNow:yyyyMMdd_HHmmss}.log");
             File.WriteAllText(file, ex.ToString());

--- a/src/ASL.CodeEngineering.AI/DotnetBuildTestRunner.cs
+++ b/src/ASL.CodeEngineering.AI/DotnetBuildTestRunner.cs
@@ -45,7 +45,8 @@ public class DotnetBuildTestRunner : IBuildTestRunner
 
     private static void Log(string operation, string content)
     {
-        var logsDir = Path.Combine(AppContext.BaseDirectory, "logs");
+        var logsDir = Environment.GetEnvironmentVariable("LOGS_DIR") ??
+                      Path.Combine(AppContext.BaseDirectory, "logs");
         Directory.CreateDirectory(logsDir);
         var file = Path.Combine(logsDir, $"{operation}_{DateTime.UtcNow:yyyyMMdd_HHmmss}.log");
         File.WriteAllText(file, content);

--- a/src/ASL.CodeEngineering.AI/PluginLoader.cs
+++ b/src/ASL.CodeEngineering.AI/PluginLoader.cs
@@ -98,7 +98,8 @@ public static class PluginLoader
         Debug.WriteLine($"{context}: {ex}");
         try
         {
-            var logsDir = Path.Combine(AppContext.BaseDirectory, "logs");
+            var logsDir = Environment.GetEnvironmentVariable("LOGS_DIR") ??
+                          Path.Combine(AppContext.BaseDirectory, "logs");
             Directory.CreateDirectory(logsDir);
             var file = Path.Combine(logsDir, $"{context}_{DateTime.UtcNow:yyyyMMdd_HHmmss}.log");
             File.WriteAllText(file, ex.ToString());

--- a/src/ASL.CodeEngineering.App/MainWindow.xaml.cs
+++ b/src/ASL.CodeEngineering.App/MainWindow.xaml.cs
@@ -138,7 +138,9 @@ namespace ASL.CodeEngineering
             SendButton.IsEnabled = true;
 
             string providerName = PathHelpers.SanitizeFileName(_aiProvider.Name);
-            string dataDir = Path.Combine(AppContext.BaseDirectory, "data", providerName);
+            string baseData = Environment.GetEnvironmentVariable("DATA_DIR") ??
+                              Path.Combine(AppContext.BaseDirectory, "data");
+            string dataDir = Path.Combine(baseData, providerName);
             Directory.CreateDirectory(dataDir);
             string chatPath = Path.Combine(dataDir, "chatlog.jsonl");
             var chatEntry = new { timestamp = DateTime.UtcNow, prompt, response };
@@ -159,7 +161,9 @@ namespace ASL.CodeEngineering
                 StatusTextBlock.Text = "Summary Error";
             }
 
-            string knowledgeDir = Path.Combine(AppContext.BaseDirectory, "knowledge_base", providerName);
+            string baseKb = Environment.GetEnvironmentVariable("KB_DIR") ??
+                            Path.Combine(AppContext.BaseDirectory, "knowledge_base");
+            string knowledgeDir = Path.Combine(baseKb, providerName);
             Directory.CreateDirectory(knowledgeDir);
             string summaryPath = Path.Combine(knowledgeDir, "summaries.jsonl");
             var summaryEntry = new { timestamp = DateTime.UtcNow, summary };
@@ -313,9 +317,10 @@ namespace ASL.CodeEngineering
 
         private static void LogError(string operation, Exception ex)
         {
-            var logsDir = Path.Combine(AppContext.BaseDirectory, "logs");
-            Directory.CreateDirectory(logsDir);
-            var file = Path.Combine(logsDir, $"{operation}_{DateTime.UtcNow:yyyyMMdd_HHmmss}.log");
+            string baseLogs = Environment.GetEnvironmentVariable("LOGS_DIR") ??
+                               Path.Combine(AppContext.BaseDirectory, "logs");
+            Directory.CreateDirectory(baseLogs);
+            var file = Path.Combine(baseLogs, $"{operation}_{DateTime.UtcNow:yyyyMMdd_HHmmss}.log");
             File.WriteAllText(file, ex.ToString());
         }
     }

--- a/tests/ASL.CodeEngineering.Tests/DotnetBuildTestRunnerTests.cs
+++ b/tests/ASL.CodeEngineering.Tests/DotnetBuildTestRunnerTests.cs
@@ -20,7 +20,8 @@ public class DotnetBuildTestRunnerTests
         var temp = Directory.CreateTempSubdirectory();
         try
         {
-            var logsDir = Path.Combine(AppContext.BaseDirectory, "logs");
+            var logsDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Environment.SetEnvironmentVariable("LOGS_DIR", logsDir);
             Directory.CreateDirectory(logsDir);
             var before = Directory.GetFiles(logsDir);
 
@@ -35,6 +36,7 @@ public class DotnetBuildTestRunnerTests
         }
         finally
         {
+            Environment.SetEnvironmentVariable("LOGS_DIR", null);
             Directory.Delete(temp.FullName, true);
         }
     }

--- a/tests/ASL.CodeEngineering.Tests/LoaderLoggingTests.cs
+++ b/tests/ASL.CodeEngineering.Tests/LoaderLoggingTests.cs
@@ -8,6 +8,7 @@ namespace ASL.CodeEngineering.Tests;
 public class LoaderLoggingTests : IDisposable
 {
     private readonly string _dir;
+    private readonly string _logsDir;
 
     public LoaderLoggingTests()
     {
@@ -16,36 +17,40 @@ public class LoaderLoggingTests : IDisposable
         Directory.CreateDirectory(Path.Combine(_dir, "ai_providers"));
         File.WriteAllText(Path.Combine(_dir, "plugins", "bad.dll"), "not a dll");
         File.WriteAllText(Path.Combine(_dir, "ai_providers", "bad.dll"), "not a dll");
+        _logsDir = Path.Combine(_dir, "logs");
     }
 
     [Fact]
     public void LoadProviders_InvalidAssembly_LogsError()
     {
-        var logsDir = Path.Combine(AppContext.BaseDirectory, "logs");
-        Directory.CreateDirectory(logsDir);
-        var before = Directory.GetFiles(logsDir);
+        Environment.SetEnvironmentVariable("LOGS_DIR", _logsDir);
+        Directory.CreateDirectory(_logsDir);
+        var before = Directory.GetFiles(_logsDir);
 
         AIProviderLoader.LoadProviders(_dir);
 
-        var after = Directory.GetFiles(logsDir);
+        var after = Directory.GetFiles(_logsDir);
         Assert.True(after.Length > before.Length);
+        Environment.SetEnvironmentVariable("LOGS_DIR", null);
     }
 
     [Fact]
     public void LoadPlugins_InvalidAssembly_LogsError()
     {
-        var logsDir = Path.Combine(AppContext.BaseDirectory, "logs");
-        Directory.CreateDirectory(logsDir);
-        var before = Directory.GetFiles(logsDir);
+        Environment.SetEnvironmentVariable("LOGS_DIR", _logsDir);
+        Directory.CreateDirectory(_logsDir);
+        var before = Directory.GetFiles(_logsDir);
 
         PluginLoader.LoadAnalyzers(_dir);
 
-        var after = Directory.GetFiles(logsDir);
+        var after = Directory.GetFiles(_logsDir);
         Assert.True(after.Length > before.Length);
+        Environment.SetEnvironmentVariable("LOGS_DIR", null);
     }
 
     public void Dispose()
     {
+        Environment.SetEnvironmentVariable("LOGS_DIR", null);
         if (Directory.Exists(_dir))
             Directory.Delete(_dir, true);
     }

--- a/tests/ASL.CodeEngineering.Tests/MainWindowEnvVarTests.cs
+++ b/tests/ASL.CodeEngineering.Tests/MainWindowEnvVarTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Windows;
+using ASL.CodeEngineering;
+using ASL.CodeEngineering.AI;
+using Xunit;
+
+namespace ASL.CodeEngineering.Tests;
+
+public class MainWindowEnvVarTests : IDisposable
+{
+    private class FailingProvider : IAIProvider
+    {
+        public string Name => "Failing";
+        public Task<string> SendChatAsync(string prompt, System.Threading.CancellationToken cancellationToken = default)
+            => throw new Exception("fail");
+    }
+
+    private readonly string _root;
+
+    public MainWindowEnvVarTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_root);
+    }
+
+    [StaFact]
+    public void SendButtonClick_UsesEnvironmentDirectories()
+    {
+        string dataDir = Path.Combine(_root, "data");
+        string kbDir = Path.Combine(_root, "kb");
+        string logsDir = Path.Combine(_root, "logs");
+        Environment.SetEnvironmentVariable("DATA_DIR", dataDir);
+        Environment.SetEnvironmentVariable("KB_DIR", kbDir);
+        Environment.SetEnvironmentVariable("LOGS_DIR", logsDir);
+
+        var window = new MainWindow();
+        var field = typeof(MainWindow).GetField("_aiProvider", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(window, new FailingProvider());
+        window.PromptTextBox.Text = "hi";
+        var method = typeof(MainWindow).GetMethod("SendButton_Click", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        method.Invoke(window, new object?[] { null, new RoutedEventArgs() });
+
+        string providerName = PathHelpers.SanitizeFileName("Failing");
+        Assert.True(File.Exists(Path.Combine(dataDir, providerName, "chatlog.jsonl")));
+        Assert.True(File.Exists(Path.Combine(kbDir, providerName, "summaries.jsonl")));
+        Assert.True(Directory.Exists(logsDir) && Directory.GetFiles(logsDir).Length > 0);
+        window.Close();
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("DATA_DIR", null);
+        Environment.SetEnvironmentVariable("KB_DIR", null);
+        Environment.SetEnvironmentVariable("LOGS_DIR", null);
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, true);
+    }
+}


### PR DESCRIPTION
## Summary
- allow overriding data, logs and knowledge base directories via `DATA_DIR`, `LOGS_DIR` and `KB_DIR`
- use these variables in loaders and build runners
- document the variables in README and REFERENCE_FILES
- add unit tests for environment variable support

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc55e332c8332836d6b818a432c8d