### PR TITLE
Handle log write errors

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -71,3 +71,9 @@ This file captures the current and upcoming steps for the project. It acts as th
 - [x] Document workflow update in REFERENCE_FILES
 - [x] Add MainWindowSummaryLoggingTests verifying summary failure logs
 - [x] Run `dotnet test`
+
+- [ ] Wrap file writes in `MainWindow.LogError` and `ProcessRunner.Log` with try/catch
+- [ ] On failure, fall back to default directory or ignore
+- [ ] Add tests for read-only `LOGS_DIR` ensuring no exceptions
+- [ ] Update `REFERENCE_FILES.md`
+- [ ] Run `dotnet test`

--- a/REFERENCE_FILES.md
+++ b/REFERENCE_FILES.md
@@ -12,9 +12,9 @@ This list tracks documents, config files and other resources that may need to be
 | `plugins/README.md` | Quick reference for building plugins |
 | `README.md` | Environment variables and duplicate name warnings |
 | `src/ASL.CodeEngineering.AI/PathHelpers.cs` | Helper for sanitizing provider names |
-| `src/ASL.CodeEngineering.App/MainWindow.xaml.cs` | Paths respect environment directories; duplicate plugin/provider names log warnings |
+| `src/ASL.CodeEngineering.App/MainWindow.xaml.cs` | Paths respect environment directories; duplicate plugin/provider names log warnings; handles log write errors |
 | `src/ASL.CodeEngineering.AI/PythonBuildTestRunner.cs` | Logs to LOGS_DIR with fallback to executable directory |
-| `src/ASL.CodeEngineering.AI/ProcessRunner.cs` | Helper to execute processes and write logs respecting LOGS_DIR |
+| `src/ASL.CodeEngineering.AI/ProcessRunner.cs` | Helper to execute processes and write logs respecting LOGS_DIR; handles log write errors |
 | `.github/labeler.yml` | Label definitions applied by Labeler workflow |
 | `.github/workflows/codeql.yml` | CodeQL analysis workflow |
 

--- a/src/ASL.CodeEngineering.AI/ProcessRunner.cs
+++ b/src/ASL.CodeEngineering.AI/ProcessRunner.cs
@@ -35,8 +35,27 @@ public static class ProcessRunner
     {
         var logsDir = Environment.GetEnvironmentVariable("LOGS_DIR") ??
                       Path.Combine(AppContext.BaseDirectory, "logs");
-        Directory.CreateDirectory(logsDir);
-        var file = Path.Combine(logsDir, $"{prefix}_{DateTime.UtcNow:yyyyMMdd_HHmmss}.log");
-        File.WriteAllText(file, content);
+
+        if (!TryWrite(logsDir))
+        {
+            var fallback = Path.Combine(AppContext.BaseDirectory, "logs");
+            if (fallback != logsDir)
+                TryWrite(fallback);
+        }
+
+        bool TryWrite(string dir)
+        {
+            try
+            {
+                Directory.CreateDirectory(dir);
+                var file = Path.Combine(dir, $"{prefix}_{DateTime.UtcNow:yyyyMMdd_HHmmss}.log");
+                File.WriteAllText(file, content);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
     }
 }

--- a/src/ASL.CodeEngineering.App/MainWindow.xaml.cs
+++ b/src/ASL.CodeEngineering.App/MainWindow.xaml.cs
@@ -361,11 +361,30 @@ namespace ASL.CodeEngineering
 
         private static void LogError(string operation, Exception ex)
         {
-            string baseLogs = Environment.GetEnvironmentVariable("LOGS_DIR") ??
-                               Path.Combine(AppContext.BaseDirectory, "logs");
-            Directory.CreateDirectory(baseLogs);
-            var file = Path.Combine(baseLogs, $"{operation}_{DateTime.UtcNow:yyyyMMdd_HHmmss}.log");
-            File.WriteAllText(file, ex.ToString());
+            string logsDir = Environment.GetEnvironmentVariable("LOGS_DIR") ??
+                              Path.Combine(AppContext.BaseDirectory, "logs");
+
+            if (!TryWrite(logsDir))
+            {
+                string fallback = Path.Combine(AppContext.BaseDirectory, "logs");
+                if (fallback != logsDir)
+                    TryWrite(fallback);
+            }
+
+            bool TryWrite(string dir)
+            {
+                try
+                {
+                    Directory.CreateDirectory(dir);
+                    var file = Path.Combine(dir, $"{operation}_{DateTime.UtcNow:yyyyMMdd_HHmmss}.log");
+                    File.WriteAllText(file, ex.ToString());
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
         }
     }
 }

--- a/tests/ASL.CodeEngineering.Tests/LogWriteErrorTests.cs
+++ b/tests/ASL.CodeEngineering.Tests/LogWriteErrorTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using ASL.CodeEngineering;
+using ASL.CodeEngineering.AI;
+using Xunit;
+using Xunit.Sdk;
+
+namespace ASL.CodeEngineering.Tests;
+
+public class LogWriteErrorTests : IDisposable
+{
+    private readonly string _dir;
+
+    public LogWriteErrorTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_dir);
+    }
+
+    [Fact]
+    public void MainWindow_LogError_ReadOnlyDir_NoException()
+    {
+        string logsDir = Path.Combine(_dir, "logs");
+        Directory.CreateDirectory(logsDir);
+        var info = new DirectoryInfo(logsDir);
+        info.Attributes |= FileAttributes.ReadOnly;
+        Environment.SetEnvironmentVariable("LOGS_DIR", logsDir);
+
+        var method = typeof(MainWindow).GetMethod("LogError", BindingFlags.NonPublic | BindingFlags.Static)!;
+        method.Invoke(null, new object?[] { "op", new Exception("fail") });
+
+        info.Attributes &= ~FileAttributes.ReadOnly;
+    }
+
+    [Fact]
+    public async Task ProcessRunner_Log_ReadOnlyDir_NoException()
+    {
+        if (!TestHelpers.ToolExists("dotnet"))
+            throw new SkipException("dotnet not installed");
+
+        string logsDir = Path.Combine(_dir, "proc_logs");
+        Directory.CreateDirectory(logsDir);
+        var info = new DirectoryInfo(logsDir);
+        info.Attributes |= FileAttributes.ReadOnly;
+        Environment.SetEnvironmentVariable("LOGS_DIR", logsDir);
+
+        await ProcessRunner.RunAsync("dotnet", "--version", _dir, "pr");
+
+        info.Attributes &= ~FileAttributes.ReadOnly;
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("LOGS_DIR", null);
+        if (Directory.Exists(_dir))
+            Directory.Delete(_dir, true);
+    }
+}


### PR DESCRIPTION
## Summary
- add fallback logic when writing logs fails
- test LOGS_DIR read-only handling
- note new behavior in reference docs

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f04ed39a0833296788fcdc3dd8863