### PR TITLE
Integrate DocsUpdater into learning cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ will update the model with harmonized data during each cycle.
 ## Documentation automation
 
 A `DocsUpdater` module watches learning cycles. Each time a cycle completes it copies `AGENTS.md` and `NEXT_STEPS.md` to `docs/archive/` with a timestamp and marks completed tasks `[x]`. It also appends a note to `AGENTS.md` for auditing.
+`AutonomousLearningEngine` calls this updater after each iteration so documentation stays in sync during automated runs.
 
 
 

--- a/REFERENCE_FILES.md
+++ b/REFERENCE_FILES.md
@@ -45,4 +45,5 @@ This list tracks documents, config files and other resources that may need to be
 | `src/ASL.CodeEngineering.AI/OfflineLearning/ModelVersionManager.cs` | Archives trained models under `data/models` |
 | `tests/ASL.CodeEngineering.Tests/OfflineLearningTests.cs` | Verifies model save/load, training, and version archiving |
 | `src/ASL.CodeEngineering.AI/DocsUpdater.cs` | Updates AGENTS and NEXT_STEPS with backups |
+| `tests/ASL.CodeEngineering.Tests/AutonomousLearningEngineDocsUpdaterTests.cs` | Verifies DocsUpdater is invoked from AutonomousLearningEngine |
 Add new entries in the table above with a short explanation of why the file might be needed again.

--- a/src/ASL.CodeEngineering.AI/AutonomousLearningEngine.cs
+++ b/src/ASL.CodeEngineering.AI/AutonomousLearningEngine.cs
@@ -94,6 +94,15 @@ public static class AutonomousLearningEngine
             }
 
             counter++;
+            try
+            {
+                DocsUpdater.RecordCycle(AppContext.BaseDirectory, null, counter);
+            }
+            catch
+            {
+                // ignore documentation update failures
+            }
+
             if (counter % 5 == 0)
             {
                 try

--- a/tests/ASL.CodeEngineering.Tests/AutonomousLearningEngineDocsUpdaterTests.cs
+++ b/tests/ASL.CodeEngineering.Tests/AutonomousLearningEngineDocsUpdaterTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ASL.CodeEngineering.AI;
+using Xunit;
+
+namespace ASL.CodeEngineering.Tests;
+
+public class AutonomousLearningEngineDocsUpdaterTests
+{
+    private class StubProvider : IAIProvider
+    {
+        public string Name => "Stub";
+        public bool RequiresNetwork => false;
+        public Task<string> SendChatAsync(string prompt, CancellationToken cancellationToken = default)
+            => Task.FromResult("ok");
+    }
+
+    [Fact]
+    public async Task RunAsync_ArchivesDocsAfterCycle()
+    {
+        string root = AppContext.BaseDirectory;
+        string agentsPath = Path.Combine(root, "AGENTS.md");
+        string nextPath = Path.Combine(root, "NEXT_STEPS.md");
+        File.WriteAllText(agentsPath, "");
+        File.WriteAllText(nextPath, "");
+
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromSeconds(6));
+        await AutonomousLearningEngine.RunAsync(() => new StubProvider(), cts.Token);
+
+        string archiveDir = Path.Combine(root, "docs", "archive");
+        Assert.True(Directory.Exists(archiveDir));
+        Assert.Contains(Directory.GetFiles(archiveDir), f => f.Contains("AGENTS_"));
+        Assert.Contains(Directory.GetFiles(archiveDir), f => f.Contains("NEXT_STEPS_"));
+        string[] agentsLines = File.ReadAllLines(agentsPath);
+        Assert.Contains(agentsLines, l => l.Contains("Learning cycle 1 completed"));
+
+        Directory.Delete(archiveDir, true);
+        Directory.Delete(Path.Combine(root, "knowledge_base"), true);
+        File.Delete(agentsPath);
+        File.Delete(nextPath);
+    }
+}


### PR DESCRIPTION
## Summary
- archive docs after each autonomous learning iteration
- test that docs are archived and AGENTS.md updated
- document integration in README
- track new test file in reference list

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861240f00f48332a01b4da96bd4be33