### PR TITLE
Add release notes generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ A login dialog now appears on startup to select a username and role. Roles contr
 
 ## Documentation automation
 
-A `DocsUpdater` module watches learning cycles. Each time a cycle completes it copies `AGENTS.md` and `NEXT_STEPS.md` to `docs/archive/` with a timestamp and marks completed tasks `[x]`. It also appends a note to `AGENTS.md` for auditing.
+A `DocsUpdater` module watches learning cycles. Each time a cycle completes it copies `AGENTS.md` and `NEXT_STEPS.md` to `docs/archive/` with a timestamp and marks completed tasks `[x]`. It also appends a note to `AGENTS.md` for auditing. When new versions are built the updater writes a Markdown report under `docs/releases/` summarizing code changes, API usage examples and recent training outcomes.
 `AutonomousLearningEngine` calls this updater after each iteration so documentation stays in sync during automated runs.
 
 ### Analytics dashboard

--- a/REFERENCE_FILES.md
+++ b/REFERENCE_FILES.md
@@ -58,6 +58,7 @@ This list tracks documents, config files and other resources that may need to be
 | `tests/ASL.CodeEngineering.Tests/TrainingMetricsAnalyzerTests.cs` | Verifies metrics are recorded correctly |
 | `src/ASL.CodeEngineering.AI/ProjectGenerator.cs` | Scaffolds new projects based on description and language |
 | `docs/archive/` | Backups of `AGENTS.md` and `NEXT_STEPS.md` after each learning cycle |
+| `docs/releases/` | Markdown reports summarizing code changes per version |
 | `tests/ASL.CodeEngineering.Tests/BuildProcessTests.cs` | Ensures BuildProcess archives versions and invokes runner |
 | `src/ASL.CodeEngineering.AI/HealthMonitor.cs` | Restarts stalled components and writes health states |
 | `src/ASL.CodeEngineering.App/UserProfile.cs` | Stores per-user preferences and recent projects |

--- a/src/ASL.CodeEngineering.AI/BuildProcess.cs
+++ b/src/ASL.CodeEngineering.AI/BuildProcess.cs
@@ -11,6 +11,14 @@ public static class BuildProcess
         string versionPath = VersionManager.SaveVersion(projectRoot);
         string srcPath = Path.Combine(versionPath, "src");
         await runner.BuildAsync(srcPath, cancellationToken);
+        try
+        {
+            DocsUpdater.GenerateReleaseReport(projectRoot, versionPath);
+        }
+        catch
+        {
+            // ignore report failures
+        }
         return versionPath;
     }
 }

--- a/src/ASL.CodeEngineering.AI/DocsUpdater.cs
+++ b/src/ASL.CodeEngineering.AI/DocsUpdater.cs
@@ -2,6 +2,8 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using System.Text.Json;
 
 namespace ASL.CodeEngineering.AI;
 
@@ -28,6 +30,114 @@ public static class DocsUpdater
         }
 
         AppendCycle(agentsPath, cycleNumber);
+    }
+
+    public static void GenerateReleaseReport(string projectRoot, string versionPath)
+    {
+        string releasesDir = Path.Combine(projectRoot, "docs", "releases");
+        Directory.CreateDirectory(releasesDir);
+        string versionName = Path.GetFileName(versionPath.TrimEnd(Path.DirectorySeparatorChar));
+        string reportPath = Path.Combine(releasesDir, $"{versionName}.md");
+
+        string dataDir = Environment.GetEnvironmentVariable("DATA_DIR") ??
+                            Path.Combine(projectRoot, "data");
+        string versionsDir = Path.Combine(dataDir, "versions");
+        string? prevVersion = Directory.GetDirectories(versionsDir)
+                                      .OrderBy(d => d)
+                                      .Where(d => d != versionPath)
+                                      .LastOrDefault();
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"# Release {versionName}");
+        sb.AppendLine();
+        sb.AppendLine("## Code Changes");
+        if (prevVersion is null)
+        {
+            sb.AppendLine("Initial version.");
+        }
+        else
+        {
+            foreach (var change in SummarizeChanges(Path.Combine(prevVersion, "src"), Path.Combine(versionPath, "src")))
+                sb.AppendLine($"- {change}");
+        }
+        sb.AppendLine();
+        sb.AppendLine("## API Usage Examples");
+        foreach (var ex in GetApiExamples(projectRoot, 3))
+            sb.AppendLine($"- `{ex.provider}`: {ex.result}");
+        sb.AppendLine();
+        sb.AppendLine("## Training Outcomes");
+        var metrics = TrainingMetricsAnalyzer.GetAverages(projectRoot);
+        if (!double.IsNaN(metrics.Loss))
+        {
+            sb.AppendLine($"- Average loss: {metrics.Loss:F3}");
+            sb.AppendLine($"- Average accuracy: {metrics.Accuracy:F3}");
+        }
+        else
+        {
+            sb.AppendLine("No training data.");
+        }
+
+        File.WriteAllText(reportPath, sb.ToString());
+    }
+
+    private static IEnumerable<string> SummarizeChanges(string prevDir, string newDir)
+    {
+        var prevFiles = Directory.Exists(prevDir)
+            ? Directory.GetFiles(prevDir, "*", SearchOption.AllDirectories)
+                .Select(f => Path.GetRelativePath(prevDir, f))
+            : Array.Empty<string>();
+        var newFiles = Directory.Exists(newDir)
+            ? Directory.GetFiles(newDir, "*", SearchOption.AllDirectories)
+                .Select(f => Path.GetRelativePath(newDir, f))
+            : Array.Empty<string>();
+
+        var prevSet = new HashSet<string>(prevFiles);
+        var newSet = new HashSet<string>(newFiles);
+
+        foreach (var added in newSet.Except(prevSet))
+            yield return $"Added {added}";
+        foreach (var removed in prevSet.Except(newSet))
+            yield return $"Removed {removed}";
+        foreach (var common in newSet.Intersect(prevSet))
+        {
+            string prevPath = Path.Combine(prevDir, common);
+            string newPath = Path.Combine(newDir, common);
+            if (!FileEquals(prevPath, newPath))
+                yield return $"Modified {common}";
+        }
+    }
+
+    private static bool FileEquals(string path1, string path2)
+    {
+        byte[] a = File.ReadAllBytes(path1);
+        byte[] b = File.ReadAllBytes(path2);
+        if (a.Length != b.Length)
+            return false;
+        for (int i = 0; i < a.Length; i++)
+            if (a[i] != b[i])
+                return false;
+        return true;
+    }
+
+    private static IEnumerable<(string provider, string result)> GetApiExamples(string projectRoot, int count)
+    {
+        string path = Path.Combine(projectRoot, "knowledge_base", "auto", "auto.jsonl");
+        if (!File.Exists(path))
+            yield break;
+        foreach (var line in File.ReadLines(path).Reverse().Take(count))
+        {
+            try
+            {
+                var doc = JsonDocument.Parse(line).RootElement;
+                string provider = doc.GetProperty("provider").GetString() ?? "";
+                string result = doc.GetProperty("result").GetString() ?? "";
+                yield return (provider, result);
+            }
+            catch
+            {
+                // ignore malformed lines
+            }
+        }
     }
 
     private static void UpdateFile(string path, IEnumerable<string> tasks)

--- a/tests/ASL.CodeEngineering.Tests/BuildProcessTests.cs
+++ b/tests/ASL.CodeEngineering.Tests/BuildProcessTests.cs
@@ -36,6 +36,12 @@ public class BuildProcessTests : IDisposable
         string dataDir = Path.Combine(_root, "data");
         Environment.SetEnvironmentVariable("DATA_DIR", dataDir);
         var runner = new RecordingRunner();
+        Directory.CreateDirectory(Path.Combine(_root, "knowledge_base", "auto"));
+        File.WriteAllText(Path.Combine(_root, "knowledge_base", "auto", "auto.jsonl"),
+            "{\"timestamp\":\"2024-01-01\",\"provider\":\"stub\",\"result\":\"ok\"}\n");
+        Directory.CreateDirectory(Path.Combine(_root, "knowledge_base", "meta"));
+        File.WriteAllText(Path.Combine(_root, "knowledge_base", "meta", "training_metrics.jsonl"),
+            "{\"timestamp\":\"2024-01-01\",\"loss\":0.5,\"accuracy\":0.7}\n");
 
         string versionPath = await BuildProcess.BuildNewVersionAsync(_root, runner);
 
@@ -46,6 +52,12 @@ public class BuildProcessTests : IDisposable
         string name = Path.GetFileName(dirs[0]);
         Assert.Matches(@"\d{8}_\d{6}", name);
         Assert.Equal(Path.Combine(versionPath, "src"), runner.BuildPath);
+
+        string releaseDir = Path.Combine(_root, "docs", "releases");
+        string releaseFile = Path.Combine(releaseDir, name + ".md");
+        Assert.True(File.Exists(releaseFile));
+        string content = File.ReadAllText(releaseFile);
+        Assert.Contains("API Usage Examples", content);
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- extend `DocsUpdater` with release report generator
- call report generator from `BuildProcess`
- capture example API usage and training outcomes in release notes
- document release notes in README and reference files
- update unit tests for new reports

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861714a59e48332bb331871fa93cece